### PR TITLE
Fixes 1 off error on memory allocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CC = gcc
 TARGET = dashboard
 DASH = dashboard.c
 
-FLAGS = -g -lcurses -Wall -Wextra -std=gnu99 -lrt 
+FLAGS = -g -lcurses -Wall -Wextra -std=gnu99 -lrt -D_GNU_SOURCE
 
 LIBCVER := $(shell ldd --version | grep "(GNU libc)" | cut -d '.' -f 2)
 RT := $(shell if [[ $(LIBCVER) -lt 18 ]]; then echo -lrt; fi)

--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -1,5 +1,3 @@
-#define _GNU_SOURCE
-
 #include <stdio.h>
 #include <sched.h>
 #include <errno.h>

--- a/src/display/display.c
+++ b/src/display/display.c
@@ -166,8 +166,8 @@ char *build_fieldbar(void)
     unsigned int max_x = getmaxx(stdscr);
     char *fieldbar;
 
-    if ((fieldbar = calloc(sizeof(char) * ALLOC_ALIGN(max_x), 
-                                     sizeof(char))) == NULL)
+    if ((fieldbar = calloc(sizeof(char) * (ALLOC_ALIGN(max_x)) + 1, 
+                                           sizeof(char))) == NULL)
         return NULL;
 
     unsigned i, head; 

--- a/src/io/disk.c
+++ b/src/io/disk.c
@@ -1,5 +1,3 @@
-#define _GNU_SOURCE
-
 #include <stdio.h>
 #include <fstab.h>
 #include <sched.h>

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -19,6 +19,7 @@ int current_fds(char *path)
 
     for (int i=0; i < open_fds; i++)
         free(fd_files[i]);
+
     free(fd_files);
 
     return open_fds;

--- a/src/process/process.c
+++ b/src/process/process.c
@@ -150,9 +150,10 @@ ps_node *get_head(ps_node *process_list)
 
 int get_current_pids(char **pid_list)
 {
-    struct dirent **proc_dir;
 
-    int total_processes = scandir(PROC, &proc_dir, is_pid, NULL);
+    struct dirent **proc_dir;
+    int total_processes = scandir(PROC, &proc_dir, NULL, NULL);//is_pid, NULL);
+
     if (total_processes == -1)
         return -1;
 

--- a/src/util/file_utils.h
+++ b/src/util/file_utils.h
@@ -28,9 +28,9 @@
 
 char *parse_stat(char *pid, int field);
 
-int is_pid(const struct dirent *directory);
-
 char *parse_proc(char *path, char *field);
+
+int is_pid(const struct dirent *directory);
 
 char *strip(char *stat);
 


### PR DESCRIPTION
When allocating memory on 64 bit the bit mask on the alignment was thrown off.  This adds one to account for the null terminator on display bar.
